### PR TITLE
docs: add OpenAI-compatible endpoint documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Once installed via `requirements.txt`, it's ready to use.
 | video to text   | ❌ Not supported yet (planned) |
 | video to voice  | ❌ Not supported yet (planned) |
 | video to video  | ❌ Not supported yet (planned) |
+| OpenAI Chat API | 🟢 Supported (agent ID as model name) |
 
 ### **Service Integrations**
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -51,6 +51,7 @@ VoicevoxEngineはローカルで稼働させる必要があります。
 | video to text   | ❌ 未対応(将来対応予定)   |
 | video to voice  | ❌ 未対応(将来対応予定)   |
 | video to video  | ❌ 未対応(将来対応予定)   |
+| OpenAI Chat API | 🟢 対応済 (エージェントIDをモデル名として使用) |
 
 ### **サービス統合**
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -41,6 +41,7 @@ Karakuri Agent is an open-source AI agent platform that enables dialogue through
    - Text/voice chat endpoints
    - Agent management
    - Health check
+   - OpenAI Chat API compatibility
 
 2. WebSocket
    - Real-time bidirectional communication


### PR DESCRIPTION
- Add OpenAI Chat API endpoint to README endpoints table
- Add OpenAI API compatibility to design documentation

This PR adds documentation for the OpenAI-compatible endpoint feature to both README files and the design document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README files to indicate support for OpenAI Chat API
	- Added OpenAI Chat API compatibility information in design documentation
	- Noted that agent ID can be used as model name for OpenAI Chat API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->